### PR TITLE
adds utils for setting executable files permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Pipfile*

--- a/utils/files.py
+++ b/utils/files.py
@@ -1,0 +1,28 @@
+"""
+    FILE UTILS
+
+    A set of utils to format files correctly.
+    i.e. set correct executable permissions.
+"""
+
+from pathlib import Path, PosixPath
+
+def find_files(base_path: str, regexp: str):
+    return list(Path(base_path).glob(regexp))
+
+def set_file_permissions_executable(files: list):
+    """sets file permissions to be executable"""
+    if not isinstance(files, list):
+        raise TypeError("Expected files to be of type 'list'.")
+
+    for file_ in files:
+        if not isinstance(file_, PosixPath):
+            file_ = Path(file_)
+        file_.chmod(0o777)
+
+if __name__ == '__main__':
+
+    bases = ["dev/base", "prod/base"]
+    for base_path in bases:
+        files = find_files('dev/base', regexp='*/**/executor.sh')
+        set_file_permissions_executable(files)


### PR DESCRIPTION
- executor.sh should have executable permissions e.g. chmod +x or "0o777"

![image](https://user-images.githubusercontent.com/28047198/123518601-e59b2f80-d6a6-11eb-857c-c40620075cf0.png)
